### PR TITLE
Add a redirect for the root uri; remove the loading of mod_ssl since

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,6 +75,9 @@ RUN echo "use_timezone=$NAGIOS_TIMEZONE" >> ${NAGIOS_HOME}/etc/nagios.cfg && ech
 # Enable https for apache (mount the key and cert as a data volume)
 ADD ssl.conf /etc/httpd/conf.d/ssl.conf
 
+# Add a redirect for the root URI
+COPY index.html /var/www/html/index.html
+
 EXPOSE 443
 
 ADD start.sh /usr/local/bin/start_nagios

--- a/index.html
+++ b/index.html
@@ -1,0 +1,8 @@
+<html>
+  <head>
+    <title>Nagios</title>
+    <meta http-equiv="refresh" content="0;URL='/nagios'" />
+  </head>
+  <body>
+  </body>
+</html>

--- a/ssl.conf
+++ b/ssl.conf
@@ -9,7 +9,6 @@
 # consult the online docs. You have been warned.
 #
 
-LoadModule ssl_module modules/mod_ssl.so
 
 #
 # When we also provide SSL we have to listen to the
@@ -219,4 +218,3 @@ CustomLog logs/ssl_request_log \
           "%t %h %{SSL_PROTOCOL}x %{SSL_CIPHER}x \"%r\" %b"
 
 </VirtualHost>
-


### PR DESCRIPTION
2 changes:

- Remove the loading of Mod_ssl since it is already loaded and generates a warning on startup
- Add an index.html file with a redirect from the root URI to /nagios

Tested locally by firing up the container and ensuring that SSL still works and the redirect works as expected